### PR TITLE
Strip whitespace from cookie name and value when evaluating prefixes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1137,6 +1137,8 @@ optional |expires|,
 |partitioned|
 run the following steps:
 
+1. Set |name| to |name|, [=stripped leading and trailing ASCII whitespace=].
+1. Set |value| to |value|, [=stripped leading and trailing ASCII whitespace=].
 1. If |name| or |value| contain U+003B (;), any [=C0 control=] character except U+0009 TAB, or U+007F DELETE, then return failure.
 
     ISSUE(httpwg/http-extensions#1593): Note that it's up for discussion whether these character restrictions should also apply to |expires|, |domain|, |path|, and |sameSite| as well.
@@ -1145,11 +1147,8 @@ run the following steps:
 1. If |name|'s [=string/length=] is 0:
     1. If |value| contains U+003D (=), then return failure.
     1. If |value|'s [=string/length=] is 0, then return failure.
-    1. If |value|, [=byte-lowercased=] and [=stripped leading and trailing ASCII whitespace=],
-          [=byte sequence/starts with=] \``__host-`\`, \``__hosthttp-`\`, \``__http-`\`, or \``__secure-`\`,
-          then return failure.
-1. If |name|, [=byte-lowercased=] and [=stripped leading and trailing ASCII whitespace=],
-      [=byte sequence/starts with=] \``__http-`\` or \``__hosthttp-`\`, then return failure.
+    1. If |value|, [=byte-lowercased=], [=byte sequence/starts with=] \``__host-`\`, \``__hosthttp-`\`, \``__http-`\`, or \``__secure-`\`, then return failure.
+1. If |name|, [=byte-lowercased=], [=byte sequence/starts with=] \``__http-`\` or \``__hosthttp-`\`, then return failure.
 1. Let |encodedName| be the result of [=UTF-8 encode|UTF-8 encoding=] |name|.
 1. Let |encodedValue| be the result of [=UTF-8 encode|UTF-8 encoding=] |value|.
 1. If the [=byte sequence=] [=byte sequence/length=] of |encodedName| plus the [=byte sequence=] [=byte sequence/length=] of |encodedValue| is greater than the <a for=cookie>maximum name/value pair size</a>, then return failure.

--- a/index.bs
+++ b/index.bs
@@ -1137,8 +1137,8 @@ optional |expires|,
 |partitioned|
 run the following steps:
 
-1. Set |name| to |name|, [=stripped leading and trailing ASCII whitespace=].
-1. Set |value| to |value|, [=stripped leading and trailing ASCII whitespace=].
+1. Remove all U+0009 or U+0020 characters that are at the start or the end of |name|.
+1. Remove all U+0009 or U+0020 characters that are at the start or the end of |value|.
 1. If |name| or |value| contain U+003B (;), any [=C0 control=] character except U+0009 TAB, or U+007F DELETE, then return failure.
 
     ISSUE(httpwg/http-extensions#1593): Note that it's up for discussion whether these character restrictions should also apply to |expires|, |domain|, |path|, and |sameSite| as well.

--- a/index.bs
+++ b/index.bs
@@ -1137,8 +1137,8 @@ optional |expires|,
 |partitioned|
 run the following steps:
 
-1. Remove all U+0009 or U+0020 characters that are at the start or the end of |name|.
-1. Remove all U+0009 or U+0020 characters that are at the start or the end of |value|.
+1. Remove all U+0009 TAB or U+0020 SPACE characters that are at the start or the end of |name|.
+1. Remove all U+0009 TAB or U+0020 SPACE characters that are at the start or the end of |value|.
 1. If |name| or |value| contain U+003B (;), any [=C0 control=] character except U+0009 TAB, or U+007F DELETE, then return failure.
 
     ISSUE(httpwg/http-extensions#1593): Note that it's up for discussion whether these character restrictions should also apply to |expires|, |domain|, |path|, and |sameSite| as well.

--- a/index.bs
+++ b/index.bs
@@ -1147,7 +1147,7 @@ run the following steps:
     1. If |value|'s [=string/length=] is 0, then return failure.
     1. If |value|, [=byte-lowercased=] and [=stripped leading and trailing ASCII whitespace=],
           [=byte sequence/starts with=] \``__host-`\`, \``__hosthttp-`\`, \``__http-`\`, or \``__secure-`\`,
-          then return failure. 
+          then return failure.
 1. If |name|, [=byte-lowercased=] and [=stripped leading and trailing ASCII whitespace=],
       [=byte sequence/starts with=] \``__http-`\` or \``__hosthttp-`\`, then return failure.
 1. Let |encodedName| be the result of [=UTF-8 encode|UTF-8 encoding=] |name|.

--- a/index.bs
+++ b/index.bs
@@ -1145,8 +1145,11 @@ run the following steps:
 1. If |name|'s [=string/length=] is 0:
     1. If |value| contains U+003D (=), then return failure.
     1. If |value|'s [=string/length=] is 0, then return failure.
-    1. If |value|, [=byte-lowercased=], [=byte sequence/starts with=] \``__host-`\`, \``__hosthttp-`\`, \``__http-`\`, or \``__secure-`\`, then return failure. 
-1. If |name|, [=byte-lowercased=], [=byte sequence/starts with=] \``__http-`\` or \``__hosthttp-`\`, then return failure.
+    1. If |value|, [=byte-lowercased=] and [=stripped leading and trailing ASCII whitespace=],
+          [=byte sequence/starts with=] \``__host-`\`, \``__hosthttp-`\`, \``__http-`\`, or \``__secure-`\`,
+          then return failure. 
+1. If |name|, [=byte-lowercased=] and [=stripped leading and trailing ASCII whitespace=],
+      [=byte sequence/starts with=] \``__http-`\` or \``__hosthttp-`\`, then return failure.
 1. Let |encodedName| be the result of [=UTF-8 encode|UTF-8 encoding=] |name|.
 1. Let |encodedValue| be the result of [=UTF-8 encode|UTF-8 encoding=] |value|.
 1. If the [=byte sequence=] [=byte sequence/length=] of |encodedName| plus the [=byte sequence=] [=byte sequence/length=] of |encodedValue| is greater than the <a for=cookie>maximum name/value pair size</a>, then return failure.

--- a/index.bs
+++ b/index.bs
@@ -1137,8 +1137,8 @@ optional |expires|,
 |partitioned|
 run the following steps:
 
-1. Remove all U+0009 TAB or U+0020 SPACE characters that are at the start or the end of |name|.
-1. Remove all U+0009 TAB or U+0020 SPACE characters that are at the start or the end of |value|.
+1. Remove all U+0009 TAB and U+0020 SPACE that are at the start or end of |name|.
+1. Remove all U+0009 TAB and U+0020 SPACE that are at the start or end of |value|.
 1. If |name| or |value| contain U+003B (;), any [=C0 control=] character except U+0009 TAB, or U+007F DELETE, then return failure.
 
     ISSUE(httpwg/http-extensions#1593): Note that it's up for discussion whether these character restrictions should also apply to |expires|, |domain|, |path|, and |sameSite| as well.


### PR DESCRIPTION
As pointed out by @annevk at https://github.com/WebKit/WebKit/pull/48318, we should verify that the prefix validation can deal with whitespaces. This PR handles that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/cookiestore/269.html" title="Last updated on Jul 29, 2025, 6:01 AM UTC (c877ed6)">Preview</a> | <a href="https://whatpr.org/cookiestore/269/0fc20e4...c877ed6.html" title="Last updated on Jul 29, 2025, 6:01 AM UTC (c877ed6)">Diff</a>