### PR TITLE
Reduce CookieListItem to only expose name and value

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -498,12 +498,6 @@ dictionary CookieStoreDeleteOptions {
 dictionary CookieListItem {
   USVString name;
   USVString value;
-  USVString? domain;
-  USVString path;
-  DOMHighResTimeStamp? expires;
-  boolean secure;
-  CookieSameSite sameSite;
-  boolean partitioned;
 };
 
 typedef sequence<CookieListItem> CookieList;
@@ -1044,44 +1038,11 @@ run the following steps:
 </div>
 
 <div algorithm>
-
-To <dfn>create a {{CookieListItem}}</dfn> from |cookie|, run the following steps.
+To <dfn>create a {{CookieListItem}}</dfn> from a [=/cookie=] |cookie|:
 
 1. Let |name| be the result of running [=UTF-8 decode without BOM=] on |cookie|'s [=cookie/name=].
 1. Let |value| be the result of running [=UTF-8 decode without BOM=] on |cookie|'s [=cookie/value=].
-1. Let |domain| be the result of running [=UTF-8 decode without BOM=] on |cookie|'s [=cookie/domain=].
-1. Let |path| be the result of running [=UTF-8 decode without BOM=] on |cookie|'s [=cookie/path=].
-1. Let |expires| be |cookie|'s [=cookie/expiry-time=] ([=as a timestamp=]).
-1. Let |secure| be |cookie|'s [=cookie/secure-only-flag=].
-1. Switch on |cookie|'s [=cookie/same-site-flag=]:
-    <dl class=switch>
-        : \``None`\`
-        :: Let |sameSite| be "{{CookieSameSite/none}}".
-        : \``Strict`\`
-        :: Let |sameSite| be "{{CookieSameSite/strict}}".
-        : \``Lax`\`
-        :: Let |sameSite| be "{{CookieSameSite/lax}}".
-    </dl>
-1. Let |partitioned| be a boolean indicating that the user agent supports [cookie partitioning](https://github.com/privacycg/CHIPS) and that that |cookie| has a partition key.
-1. Return «[
-    "name" → |name|,
-    "value" → |value|,
-    "domain" → |domain|,
-    "path" → |path|,
-    "expires" → |expires|,
-    "secure" → |secure|,
-    "sameSite" → |sameSite|,
-    "partitioned" → |partitioned|
-    ]»
-
-Note: The |cookie|'s
-[=cookie/creation-time=],
-[=cookie/last-access-time=],
-[=cookie/persistent-flag=],
-[=cookie/host-only-flag=], and
-[=cookie/http-only-flag=]
-attributes are not exposed to script.
-
+1. Return «[ "{{CookieListItem/name}}" → |name|, "{{CookieListItem/value}}" → |value| ]».
 </div>
 
 <!-- ============================================================ -->


### PR DESCRIPTION
We never had agreement to expose more than information than document.cookie, so make the standard reflect that.

Tests: TODO.

Fixes #238 and closes #241.

<!--
Thank you for contributing to the Cookie Store API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * Gecko
   * WebKit
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * … <!-- If these tests are tentative, link a PR to make them non-tentative. -->
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: N/A
   * WebKit: N/A
- [ ] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: …
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
