### PR TITLE
Correct delete a cookie invocation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -722,9 +722,8 @@ The <dfn method for=CookieStore>delete(|name|)</dfn> method steps are:
         |url|,
         |name|,
         null,
-        "`/`",
-        true, and
-        "{{CookieSameSite/strict}}".
+        "`/`", and
+        true.
     1. If |r| is failure, then [=reject=] |p| with a {{TypeError}} and abort these steps.
     1. [=/Resolve=] |p| with undefined.
 1. Return |p|.
@@ -1185,11 +1184,6 @@ run the following steps:
 
 1. If |name|'s [=string/length=] is 0, then set |value| to any non-empty [=implementation-defined=] string.
 
-1. Let |sameSite| be "{{CookieSameSite/strict}}".
-
-    Note: The values for |value|, and |sameSite| will not be persisted
-    by this algorithm.
-
 1. Return the results of running [=set a cookie=] with
     |url|,
     |name|,
@@ -1197,7 +1191,7 @@ run the following steps:
     |expires|,
     |domain|,
     |path|,
-    |sameSite|, and
+    "{{CookieSameSite/strict}}", and
     |partitioned|.
 
 </div>


### PR DESCRIPTION
Delete a cookie doesn't take a sameSite parameter. Also remove a confusing note.

Fixes #277.