### PR TITLE
Default empty string paths to URL's path

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1086,7 +1086,7 @@ run the following steps:
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
-1. If |path| is the empty string, then set |path| to the [=URL path serialization=] of |url|.
+1. If |path| is the empty string, then set |path| to the [=/URL path serializer|URL path serialization=] of |url|.
 1. If |path| does not start with U+002F (/), then return failure.
 1. If |path| is not U+002F (/), and |name|, [=byte-lowercased=], [=byte sequence/starts with=] \``__host-`\`, then return failure.
 1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.

--- a/index.bs
+++ b/index.bs
@@ -1086,13 +1086,12 @@ run the following steps:
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
-1. If |path| is not null:
-    1. If |path| does not start with U+002F (/), then return failure.
-    1. If |path| is not U+002F (/), and |name|, [=byte-lowercased=], [=byte sequence/starts with=] \``__host-`\`, then return failure.
-    1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
-    1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
-    1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
-1. Otherwise, [=list/append=] \``Path`\`/ U+002F (/) to |attributes|.
+1. If |path| is the empty string, then set |path| to the [=URL path serialization=] of |url|.
+1. If |path| does not start with U+002F (/), then return failure.
+1. If |path| is not U+002F (/), and |name|, [=byte-lowercased=], [=byte sequence/starts with=] \``__host-`\`, then return failure.
+1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.
+1. If the [=byte sequence=] [=byte sequence/length=] of |encodedPath| is greater than the [=cookie/maximum attribute value size=], then return failure.
+1. [=list/Append=] \``Path`\`/|encodedPath| to |attributes|.
 1. [=list/Append=] \``Secure`\`/\`\` to |attributes|.
 1. Switch on |sameSite|:
     <dl class=switch>

--- a/index.bs
+++ b/index.bs
@@ -1086,7 +1086,7 @@ run the following steps:
     1. If the [=byte sequence=] [=byte sequence/length=] of |encodedDomain| is greater than the [=cookie/maximum attribute value size=], then return failure.
     1. [=list/Append=] \``Domain`\`/|encodedDomain| to |attributes|.
 1. If |expires| is given, then [=list/append=] \``Expires`\`/|expires| ([=date serialized=]) to |attributes|.
-1. If |path| is the empty string, then set |path| to the [=/URL path serializer|URL path serialization=] of |url|.
+1. If |path| is the empty string, then set |path| to the [=/serialized cookie default path=] of |url|.
 1. If |path| does not start with U+002F (/), then return failure.
 1. If |path| is not U+002F (/), and |name|, [=byte-lowercased=], [=byte sequence/starts with=] \``__host-`\`, then return failure.
 1. Let |encodedPath| be the result of [=UTF-8 encode|UTF-8 encoding=] |path|.


### PR DESCRIPTION
Also correct the algorithm as it incorrectly assumed that path could be null when in fact it's always a string.

Tests: https://github.com/web-platform-tests/wpt/pull/54264

Closes #242. 

<!--
Thank you for contributing to the Cookie Store API Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.

When you submit this PR, and each time you edit this comment (including checking a checkbox through the UI!), PR Preview will run and update it. As such make any edits in one go and only after PR Preview has run.

If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [x] At least two implementers are interested (and none opposed):
   * WebKit
   * Chromium
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * https://github.com/web-platform-tests/wpt/pull/54264
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chromium: …
   * Gecko: …
   * WebKit: https://bugs.webkit.org/show_bug.cgi?id=297268
- [x] [MDN issue](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) is filed: N/A
- [x] The top of this comment includes a [clear commit message](https://github.com/whatwg/meta/blob/main/COMMITTING.md) to use. <!-- If you created this PR from a single commit, Github copied its message. Otherwise, you need to add a commit message yourself. -->

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/cookiestore/283.html" title="Last updated on Aug 13, 2025, 7:12 AM UTC (7f81ad7)">Preview</a> | <a href="https://whatpr.org/cookiestore/283/6f3df44...7f81ad7.html" title="Last updated on Aug 13, 2025, 7:12 AM UTC (7f81ad7)">Diff</a>